### PR TITLE
Improve dashboard shell spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12358,6 +12358,7 @@ html[data-sb-collapsed='1'][data-sb-peek='1'] {
   grid-template-columns: 1fr;
   gap: clamp(16px, 4vw, 28px);
   align-items: flex-start;
+  padding: clamp(12px, 4vw, 22px);
   min-height: calc(100vh - var(--neo-header-height));
   min-height: calc(100dvh - var(--neo-header-height));
 }
@@ -12372,8 +12373,9 @@ html[data-sb-collapsed='1'][data-sb-peek='1'] {
 }
 
 .neo-shell__main {
-  padding: 24px clamp(16px, 4vw, 32px);
-  width: 100%;
+  padding: clamp(18px, 3vw, 28px) clamp(16px, 4vw, 32px);
+  width: min(1280px, 100%);
+  margin-inline: auto;
   min-width: 0;
   min-height: calc(100vh - var(--neo-header-height));
   min-height: calc(100dvh - var(--neo-header-height));


### PR DESCRIPTION
## Summary
- add responsive padding to the dashboard shell body so content no longer touches the viewport edges
- cap and center the main column width to restore readable layouts on large screens

## Testing
- npm run test:unit
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941c2dff0e08323b39e917e103c0a2b)